### PR TITLE
Hide TX list chevron before auth

### DIFF
--- a/Frontend/Layout/BottomMenu.razor.css
+++ b/Frontend/Layout/BottomMenu.razor.css
@@ -69,9 +69,7 @@
     text-decoration: none;
 }
 
-
 .loading-spinner .spinner {
     width: 40px;
     height: 40px;
 }
-

--- a/Frontend/Layout/MainLayout.razor
+++ b/Frontend/Layout/MainLayout.razor
@@ -18,7 +18,10 @@
 			@Body
 		</article>
 	</main>
-	<BottomMenu />
+	@if (!NavManager.Uri.Contains("Login") && !NavManager.Uri.Contains("Register"))
+	{
+		<BottomMenu />
+	}
 </div>
 
 @code {


### PR DESCRIPTION
BottomMenu/SlidingMenu ^ was non functioning on Registration and Login pages. And made no sense to exist on them.

Also user (read: me) was not noticing TX list from it cause ^ "was always there". 

Now when it appears after login, user understands that it's something functional.

Hopefully this PR pleases you.